### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/vote.php
+++ b/syntax/vote.php
@@ -30,7 +30,7 @@ class syntax_plugin_schulzevote_vote extends DokuWiki_Syntax_Plugin {
          $this->Lexer->addSpecialPattern('<vote[ a-z0-9-]*?>\n.*?\n</vote>',$mode,'plugin_schulzevote_vote');
     }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $lines = explode("\n", $match);
 
         $opts = array();
@@ -69,7 +69,7 @@ class syntax_plugin_schulzevote_vote extends DokuWiki_Syntax_Plugin {
         return array('candy' => $candidates, 'opts' => $opts);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 
         if ($mode != 'xhtml') return false;
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.